### PR TITLE
added maps folder to fix compile error

### DIFF
--- a/mbot_navigation/maps/.placeholder
+++ b/mbot_navigation/maps/.placeholder
@@ -1,0 +1,1 @@
+This is to keep the maps folder stay visible to git.


### PR DESCRIPTION
Forgot to put a placeholder file under the `mbot_navigation/maps` folder, and git does not track empty directories, results in compile error as following due to maps folder missing.
```
Starting >>> camera_ros
Starting >>> mbot_description
Starting >>> mbot_navigation
Starting >>> mbot_interfaces
--- stderr: mbot_navigation                                                                                                                                
CMake Error at ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:100 (message):
  ament_cmake_symlink_install_directory() can't find
  '/home/mbot/mbot_ws/src/mbot_navigation/maps'
Call Stack (most recent call first):
  ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:314 (ament_cmake_symlink_install_directory)
  cmake_install.cmake:46 (include)


---
Failed   <<< mbot_navigation [1.17s, exited with code 1]
Aborted  <<< mbot_description [1.59s]                                                                                                  
Aborted  <<< camera_ros [1.86s]                                                                      
Aborted  <<< mbot_interfaces [2.40s]                           

Summary: 0 packages finished [2.95s]
  1 package failed: mbot_navigation
  3 packages aborted: camera_ros mbot_description mbot_interfaces
  1 package had stderr output: mbot_navigation
  3 packages not processed
```

One minor push to solve this problem, but simply adding a `.placeholder` file.