### PR TITLE
removed opencv2 rosdep - redundant and wrong

### DIFF
--- a/mbot_vision/package.xml
+++ b/mbot_vision/package.xml
@@ -9,16 +9,16 @@
 
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>apriltag_msgs</depend>
+  <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
+
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>image_proc</exec_depend>
   <exec_depend>apriltag_ros</exec_depend>
-  <exec_depend>apriltag_msgs</exec_depend>
-  <exec_depend>cv_bridge</exec_depend>
-  <exec_depend>opencv2</exec_depend>
-  <exec_depend>image_transport</exec_depend>
   <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>camera_ros</exec_depend>
 


### PR DESCRIPTION
Found out during rob550 lab, the opencv2 is not the name for ros depends, and also we don't need to include it seperately. [cv_bridge](https://github.com/ros-perception/vision_opencv/tree/rolling/cv_bridge) brings in OpenCV and all requirements.